### PR TITLE
55_кастомные тэги

### DIFF
--- a/uikit/src/main/java/com/davai/uikit/TagView.kt
+++ b/uikit/src/main/java/com/davai/uikit/TagView.kt
@@ -9,6 +9,7 @@ import android.widget.TextView
 import androidx.annotation.AttrRes
 import androidx.annotation.StyleRes
 
+@Suppress("Detekt:MagicNumber")
 class TagView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
@@ -67,23 +68,23 @@ class TagView @JvmOverloads constructor(
             1 -> {
                 vtText?.setBackgroundResource(R.drawable.tag_primary_violet_background)
                 vtText?.setTextColor(context.getColor(R.color.text_light))
-                setPaddings(12, 4)
+                setPaddings(PADDING_SMALL_HORIZONTAL, PADDING_SMALL_VERTICAL)
             }
             2 -> {
                 vtText?.setBackgroundResource(R.drawable.tag_primary_gray_background)
                 vtText?.setTextColor(context.getColor(R.color.text_base))
-                setPaddings(12, 4)
-             }
+                setPaddings(PADDING_SMALL_HORIZONTAL, PADDING_SMALL_VERTICAL)
+            }
             3 -> {
                 vtText?.setBackgroundResource(R.drawable.tag_secodary_green_background)
                 vtText?.setTextColor(context.getColor(R.color.tertiary_base))
-                setPaddings(20, 8)
+                setPaddings(PADDING_BIG_HORIZONTAL, PADDING_BIG_VERTICAL)
             }
             4 -> {
                 vtText?.setBackgroundResource(R.drawable.tag_secondary_gray_background)
                 vtText?.setTextColor(context.getColor(R.color.text_caption_dark))
-                setPaddings(20, 8)
-             }
+                setPaddings(PADDING_BIG_HORIZONTAL, PADDING_BIG_VERTICAL)
+            }
         }
     }
 
@@ -94,5 +95,12 @@ class TagView @JvmOverloads constructor(
             (horizontal * resources.displayMetrics.density).toInt(),
             (vertical * resources.displayMetrics.density).toInt(),
         )
+    }
+
+    private companion object {
+        const val PADDING_SMALL_HORIZONTAL = 12
+        const val PADDING_SMALL_VERTICAL = 4
+        const val PADDING_BIG_HORIZONTAL = 20
+        const val PADDING_BIG_VERTICAL = 8
     }
 }

--- a/uikit/src/main/java/com/davai/uikit/TagView.kt
+++ b/uikit/src/main/java/com/davai/uikit/TagView.kt
@@ -72,28 +72,28 @@ class TagView @JvmOverloads constructor(
                     it.setBackgroundResource(R.drawable.tag_primary_violet_background)
                     it.setTextColor(context.getColor(R.color.text_light))
                 }
-                setPaddings(PADDING_12_HORIZONTAL_DP, PADDING_4_VERTICAL_DP)
+                setPaddings(PADDING_HORIZONTAL_12_DP, PADDING_VERTICAL_4_DP)
             }
             STYLE_PRIMARY_GRAY -> {
                 tvTagText?.let {
                     it.setBackgroundResource(R.drawable.tag_primary_gray_background)
                     it.setTextColor(context.getColor(R.color.text_base))
                 }
-                setPaddings(PADDING_12_HORIZONTAL_DP, PADDING_4_VERTICAL_DP)
+                setPaddings(PADDING_HORIZONTAL_12_DP, PADDING_VERTICAL_4_DP)
             }
             STYLE_SECONDARY_GREEN -> {
                 tvTagText?.let {
                     it.setBackgroundResource(R.drawable.tag_secodary_green_background)
                     it.setTextColor(context.getColor(R.color.text_base))
                 }
-                setPaddings(PADDING_20_HORIZONTAL_DP, PADDING_8_VERTICAL_DP)
+                setPaddings(PADDING_HORIZONTAL_20_DP, PADDING_VERTICAL_8_DP)
             }
             STYLE_SECONDARY_GRAY -> {
                 tvTagText?.let {
                     it.setBackgroundResource(R.drawable.tag_secondary_gray_background)
                     it.setTextColor(context.getColor(R.color.text_caption_dark))
                 }
-                setPaddings(PADDING_20_HORIZONTAL_DP, PADDING_8_VERTICAL_DP)
+                setPaddings(PADDING_HORIZONTAL_20_DP, PADDING_VERTICAL_8_DP)
             }
             STYLE_ONBOARDING_YELLOW -> {
                 tvTagText?.let {
@@ -101,7 +101,7 @@ class TagView @JvmOverloads constructor(
                     it.setTextColor(context.getColor(R.color.text_base))
                     it.setTextAppearance(R.style.Text_Base_SplashItem)
                 }
-                setPaddings(PADDING_20_HORIZONTAL_DP, PADDING_8_VERTICAL_DP)
+                setPaddings(PADDING_HORIZONTAL_20_DP, PADDING_VERTICAL_8_DP)
             }
             STYLE_ONBOARDING_VIOLET -> {
                 tvTagText?.let {
@@ -109,7 +109,7 @@ class TagView @JvmOverloads constructor(
                     it.setTextColor(context.getColor(R.color.text_light))
                     it.setTextAppearance(R.style.Text_Base_SplashItem)
                 }
-                setPaddings(PADDING_20_HORIZONTAL_DP, PADDING_8_VERTICAL_DP)
+                setPaddings(PADDING_HORIZONTAL_20_DP, PADDING_VERTICAL_8_DP)
             }
         }
     }
@@ -124,10 +124,10 @@ class TagView @JvmOverloads constructor(
     }
 
     companion object {
-        private const val PADDING_12_HORIZONTAL_DP = 12
-        private const val PADDING_4_VERTICAL_DP = 4
-        private const val PADDING_20_HORIZONTAL_DP = 20
-        private const val PADDING_8_VERTICAL_DP = 8
+        private const val PADDING_HORIZONTAL_12_DP = 12
+        private const val PADDING_HORIZONTAL_20_DP = 20
+        private const val PADDING_VERTICAL_4_DP = 4
+        private const val PADDING_VERTICAL_8_DP = 8
 
         private const val STYLE_PRIMARY_VIOLET = 1
         private const val STYLE_PRIMARY_GRAY = 2

--- a/uikit/src/main/java/com/davai/uikit/TagView.kt
+++ b/uikit/src/main/java/com/davai/uikit/TagView.kt
@@ -1,0 +1,98 @@
+package com.davai.uikit
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.widget.FrameLayout
+import android.widget.TextView
+import androidx.annotation.AttrRes
+import androidx.annotation.StyleRes
+
+class TagView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    @AttrRes defStyleAttr: Int = 0,
+    @StyleRes defStyleRes: Int = 0
+) : FrameLayout(context, attrs, defStyleAttr, defStyleRes) {
+
+    private var vtText: TextView? = null
+    private var tagType: Int = 1
+
+    init {
+        initViews()
+        applyAttributes(context, attrs, defStyleAttr, defStyleRes)
+    }
+
+    private fun initViews() {
+        LayoutInflater.from(context).inflate(R.layout.tag_view, this)
+        vtText = findViewById(R.id.tv_tag_view)
+    }
+
+    @SuppressLint("ResourceType")
+    private fun applyAttributes(
+        context: Context,
+        attrs: AttributeSet?,
+        defStyleAttr: Int,
+        defStyleRes: Int
+    ) {
+        context.theme.obtainStyledAttributes(
+            attrs,
+            R.styleable.TagView,
+            defStyleAttr,
+            defStyleRes
+        ).apply {
+            vtText?.text = getString(R.styleable.TagView_tag_text)
+            tagType = getInt(R.styleable.TagView_tag_type, 1)
+            setStyle(tagType)
+        }
+    }
+
+    fun setText(text: String) {
+        vtText?.text = text
+    }
+
+    fun setChosen() {
+        vtText?.setBackgroundResource(R.drawable.tag_secodary_green_background)
+        vtText?.setTextColor(context.getColor(R.color.tertiary_base))
+    }
+
+    fun setDisabled() {
+        vtText?.setBackgroundResource(R.drawable.tag_secondary_gray_background)
+        vtText?.setTextColor(context.getColor(R.color.text_caption_dark))
+    }
+
+    private fun setStyle(type: Int) {
+        when (type) {
+            1 -> {
+                vtText?.setBackgroundResource(R.drawable.tag_primary_violet_background)
+                vtText?.setTextColor(context.getColor(R.color.text_light))
+                setPaddings(12, 4)
+            }
+            2 -> {
+                vtText?.setBackgroundResource(R.drawable.tag_primary_gray_background)
+                vtText?.setTextColor(context.getColor(R.color.text_base))
+                setPaddings(12, 4)
+             }
+            3 -> {
+                vtText?.setBackgroundResource(R.drawable.tag_secodary_green_background)
+                vtText?.setTextColor(context.getColor(R.color.tertiary_base))
+                setPaddings(20, 8)
+            }
+            4 -> {
+                vtText?.setBackgroundResource(R.drawable.tag_secondary_gray_background)
+                vtText?.setTextColor(context.getColor(R.color.text_caption_dark))
+                setPaddings(20, 8)
+             }
+        }
+    }
+
+    private fun setPaddings(horizontal: Int, vertical: Int) {
+        vtText?.setPadding(
+            (horizontal * resources.displayMetrics.density).toInt(),
+            (vertical * resources.displayMetrics.density).toInt(),
+            (horizontal * resources.displayMetrics.density).toInt(),
+            (vertical * resources.displayMetrics.density).toInt(),
+        )
+    }
+}

--- a/uikit/src/main/java/com/davai/uikit/TagView.kt
+++ b/uikit/src/main/java/com/davai/uikit/TagView.kt
@@ -1,6 +1,5 @@
 package com.davai.uikit
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
@@ -9,7 +8,6 @@ import android.widget.TextView
 import androidx.annotation.AttrRes
 import androidx.annotation.StyleRes
 
-@Suppress("Detekt:MagicNumber")
 class TagView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
@@ -17,7 +15,7 @@ class TagView @JvmOverloads constructor(
     @StyleRes defStyleRes: Int = 0
 ) : FrameLayout(context, attrs, defStyleAttr, defStyleRes) {
 
-    private var vtText: TextView? = null
+    private var tvTagText: TextView? = null
     private var tagType: Int = 1
 
     init {
@@ -27,10 +25,9 @@ class TagView @JvmOverloads constructor(
 
     private fun initViews() {
         LayoutInflater.from(context).inflate(R.layout.tag_view, this)
-        vtText = findViewById(R.id.tv_tag_view)
+        tvTagText = findViewById(R.id.tv_tag_view)
     }
 
-    @SuppressLint("ResourceType")
     private fun applyAttributes(
         context: Context,
         attrs: AttributeSet?,
@@ -43,53 +40,85 @@ class TagView @JvmOverloads constructor(
             defStyleAttr,
             defStyleRes
         ).apply {
-            vtText?.text = getString(R.styleable.TagView_tag_text)
-            tagType = getInt(R.styleable.TagView_tag_type, 1)
-            setStyle(tagType)
+            try {
+                tvTagText?.text = getString(R.styleable.TagView_tag_text)
+                tagType = getInt(R.styleable.TagView_tag_type, 1)
+                setStyle(tagType)
+            } finally {
+                recycle()
+            }
         }
     }
 
     fun setText(text: String) {
-        vtText?.text = text
+        tvTagText?.text = text
     }
 
     fun setChosen() {
-        vtText?.setBackgroundResource(R.drawable.tag_secodary_green_background)
-        vtText?.setTextColor(context.getColor(R.color.tertiary_base))
+        tvTagText?.let {
+            it.setBackgroundResource(R.drawable.tag_secodary_green_background)
+            it.setTextColor(context.getColor(R.color.tertiary_base))
+        }
     }
 
     fun setDisabled() {
-        vtText?.setBackgroundResource(R.drawable.tag_secondary_gray_background)
-        vtText?.setTextColor(context.getColor(R.color.text_caption_dark))
+        tvTagText?.let {
+            it.setBackgroundResource(R.drawable.tag_secondary_gray_background)
+            it.setTextColor(context.getColor(R.color.text_caption_dark))
+        }
     }
 
     private fun setStyle(type: Int) {
         when (type) {
-            1 -> {
-                vtText?.setBackgroundResource(R.drawable.tag_primary_violet_background)
-                vtText?.setTextColor(context.getColor(R.color.text_light))
-                setPaddings(PADDING_SMALL_HORIZONTAL, PADDING_SMALL_VERTICAL)
+            STYLE_PRIMARY_VIOLET -> {
+                tvTagText?.let {
+                    it.setBackgroundResource(R.drawable.tag_primary_violet_background)
+                    it.setTextColor(context.getColor(R.color.text_light))
+                }
+                setPaddings(PADDING_SMALL_HORIZONTAL_DP, PADDING_SMALL_VERTICAL_DP)
             }
-            2 -> {
-                vtText?.setBackgroundResource(R.drawable.tag_primary_gray_background)
-                vtText?.setTextColor(context.getColor(R.color.text_base))
-                setPaddings(PADDING_SMALL_HORIZONTAL, PADDING_SMALL_VERTICAL)
+            STYLE_PRIMARY_GRAY -> {
+                tvTagText?.let {
+                    it.setBackgroundResource(R.drawable.tag_primary_gray_background)
+                    it.setTextColor(context.getColor(R.color.text_base))
+                }
+                setPaddings(PADDING_SMALL_HORIZONTAL_DP, PADDING_SMALL_VERTICAL_DP)
             }
-            3 -> {
-                vtText?.setBackgroundResource(R.drawable.tag_secodary_green_background)
-                vtText?.setTextColor(context.getColor(R.color.tertiary_base))
-                setPaddings(PADDING_BIG_HORIZONTAL, PADDING_BIG_VERTICAL)
+            STYLE_SECONDARY_GREEN -> {
+                tvTagText?.let {
+                    it.setBackgroundResource(R.drawable.tag_secodary_green_background)
+                    it.setTextColor(context.getColor(R.color.text_base))
+                }
+                setPaddings(PADDING_BIG_HORIZONTAL_DP, PADDING_BIG_VERTICAL_DP)
             }
-            4 -> {
-                vtText?.setBackgroundResource(R.drawable.tag_secondary_gray_background)
-                vtText?.setTextColor(context.getColor(R.color.text_caption_dark))
-                setPaddings(PADDING_BIG_HORIZONTAL, PADDING_BIG_VERTICAL)
+            STYLE_SECONDARY_GRAY -> {
+                tvTagText?.let {
+                    it.setBackgroundResource(R.drawable.tag_secondary_gray_background)
+                    it.setTextColor(context.getColor(R.color.text_caption_dark))
+                }
+                setPaddings(PADDING_BIG_HORIZONTAL_DP, PADDING_BIG_VERTICAL_DP)
+            }
+            STYLE_ONBOARDING_YELLOW -> {
+                tvTagText?.let {
+                    it.setBackgroundResource(R.drawable.tag_onboadring_yellow_background)
+                    it.setTextColor(context.getColor(R.color.text_base))
+                    it.setTextAppearance(R.style.Text_Base_SplashItem)
+                }
+                setPaddings(PADDING_BIG_HORIZONTAL_DP, PADDING_BIG_VERTICAL_DP)
+            }
+            STYLE_ONBOARDING_VIOLET -> {
+                tvTagText?.let {
+                    it.setBackgroundResource(R.drawable.tag_onboarding_violet_background)
+                    it.setTextColor(context.getColor(R.color.text_light))
+                    it.setTextAppearance(R.style.Text_Base_SplashItem)
+                }
+                setPaddings(PADDING_BIG_HORIZONTAL_DP, PADDING_BIG_VERTICAL_DP)
             }
         }
     }
 
     private fun setPaddings(horizontal: Int, vertical: Int) {
-        vtText?.setPadding(
+        tvTagText?.setPadding(
             (horizontal * resources.displayMetrics.density).toInt(),
             (vertical * resources.displayMetrics.density).toInt(),
             (horizontal * resources.displayMetrics.density).toInt(),
@@ -98,9 +127,16 @@ class TagView @JvmOverloads constructor(
     }
 
     private companion object {
-        const val PADDING_SMALL_HORIZONTAL = 12
-        const val PADDING_SMALL_VERTICAL = 4
-        const val PADDING_BIG_HORIZONTAL = 20
-        const val PADDING_BIG_VERTICAL = 8
+        const val PADDING_SMALL_HORIZONTAL_DP = 12
+        const val PADDING_SMALL_VERTICAL_DP = 4
+        const val PADDING_BIG_HORIZONTAL_DP = 20
+        const val PADDING_BIG_VERTICAL_DP = 8
+
+        const val STYLE_PRIMARY_VIOLET = 1
+        const val STYLE_PRIMARY_GRAY = 2
+        const val STYLE_SECONDARY_GREEN = 3
+        const val STYLE_SECONDARY_GRAY = 4
+        const val STYLE_ONBOARDING_YELLOW = 5
+        const val STYLE_ONBOARDING_VIOLET = 6
     }
 }

--- a/uikit/src/main/java/com/davai/uikit/TagView.kt
+++ b/uikit/src/main/java/com/davai/uikit/TagView.kt
@@ -72,28 +72,28 @@ class TagView @JvmOverloads constructor(
                     it.setBackgroundResource(R.drawable.tag_primary_violet_background)
                     it.setTextColor(context.getColor(R.color.text_light))
                 }
-                setPaddings(PADDING_SMALL_HORIZONTAL_DP, PADDING_SMALL_VERTICAL_DP)
+                setPaddings(PADDING_12_HORIZONTAL_DP, PADDING_4_VERTICAL_DP)
             }
             STYLE_PRIMARY_GRAY -> {
                 tvTagText?.let {
                     it.setBackgroundResource(R.drawable.tag_primary_gray_background)
                     it.setTextColor(context.getColor(R.color.text_base))
                 }
-                setPaddings(PADDING_SMALL_HORIZONTAL_DP, PADDING_SMALL_VERTICAL_DP)
+                setPaddings(PADDING_12_HORIZONTAL_DP, PADDING_4_VERTICAL_DP)
             }
             STYLE_SECONDARY_GREEN -> {
                 tvTagText?.let {
                     it.setBackgroundResource(R.drawable.tag_secodary_green_background)
                     it.setTextColor(context.getColor(R.color.text_base))
                 }
-                setPaddings(PADDING_BIG_HORIZONTAL_DP, PADDING_BIG_VERTICAL_DP)
+                setPaddings(PADDING_20_HORIZONTAL_DP, PADDING_8_VERTICAL_DP)
             }
             STYLE_SECONDARY_GRAY -> {
                 tvTagText?.let {
                     it.setBackgroundResource(R.drawable.tag_secondary_gray_background)
                     it.setTextColor(context.getColor(R.color.text_caption_dark))
                 }
-                setPaddings(PADDING_BIG_HORIZONTAL_DP, PADDING_BIG_VERTICAL_DP)
+                setPaddings(PADDING_20_HORIZONTAL_DP, PADDING_8_VERTICAL_DP)
             }
             STYLE_ONBOARDING_YELLOW -> {
                 tvTagText?.let {
@@ -101,7 +101,7 @@ class TagView @JvmOverloads constructor(
                     it.setTextColor(context.getColor(R.color.text_base))
                     it.setTextAppearance(R.style.Text_Base_SplashItem)
                 }
-                setPaddings(PADDING_BIG_HORIZONTAL_DP, PADDING_BIG_VERTICAL_DP)
+                setPaddings(PADDING_20_HORIZONTAL_DP, PADDING_8_VERTICAL_DP)
             }
             STYLE_ONBOARDING_VIOLET -> {
                 tvTagText?.let {
@@ -109,7 +109,7 @@ class TagView @JvmOverloads constructor(
                     it.setTextColor(context.getColor(R.color.text_light))
                     it.setTextAppearance(R.style.Text_Base_SplashItem)
                 }
-                setPaddings(PADDING_BIG_HORIZONTAL_DP, PADDING_BIG_VERTICAL_DP)
+                setPaddings(PADDING_20_HORIZONTAL_DP, PADDING_8_VERTICAL_DP)
             }
         }
     }
@@ -124,10 +124,10 @@ class TagView @JvmOverloads constructor(
     }
 
     companion object {
-        private const val PADDING_SMALL_HORIZONTAL_DP = 12
-        private const val PADDING_SMALL_VERTICAL_DP = 4
-        private const val PADDING_BIG_HORIZONTAL_DP = 20
-        private const val PADDING_BIG_VERTICAL_DP = 8
+        private const val PADDING_12_HORIZONTAL_DP = 12
+        private const val PADDING_4_VERTICAL_DP = 4
+        private const val PADDING_20_HORIZONTAL_DP = 20
+        private const val PADDING_8_VERTICAL_DP = 8
 
         private const val STYLE_PRIMARY_VIOLET = 1
         private const val STYLE_PRIMARY_GRAY = 2

--- a/uikit/src/main/java/com/davai/uikit/TagView.kt
+++ b/uikit/src/main/java/com/davai/uikit/TagView.kt
@@ -54,17 +54,14 @@ class TagView @JvmOverloads constructor(
         tvTagText?.text = text
     }
 
-    fun setChosen() {
-        tvTagText?.let {
-            it.setBackgroundResource(R.drawable.tag_secodary_green_background)
-            it.setTextColor(context.getColor(R.color.tertiary_base))
-        }
-    }
-
-    fun setDisabled() {
-        tvTagText?.let {
-            it.setBackgroundResource(R.drawable.tag_secondary_gray_background)
-            it.setTextColor(context.getColor(R.color.text_caption_dark))
+    fun changeStyle(style: Style) {
+        when (style) {
+            Style.PRIMARY_VIOLET -> setStyle(STYLE_PRIMARY_VIOLET)
+            Style.PRIMARY_GRAY -> setStyle(STYLE_PRIMARY_GRAY)
+            Style.SECONDARY_GREEN -> setStyle(STYLE_SECONDARY_GREEN)
+            Style.SECONDARY_GRAY -> setStyle(STYLE_SECONDARY_GRAY)
+            Style.ONBOARDING_YELLOW -> setStyle(STYLE_ONBOARDING_YELLOW)
+            Style.ONBOARDING_VIOLET -> setStyle(STYLE_ONBOARDING_VIOLET)
         }
     }
 
@@ -126,17 +123,26 @@ class TagView @JvmOverloads constructor(
         )
     }
 
-    private companion object {
-        const val PADDING_SMALL_HORIZONTAL_DP = 12
-        const val PADDING_SMALL_VERTICAL_DP = 4
-        const val PADDING_BIG_HORIZONTAL_DP = 20
-        const val PADDING_BIG_VERTICAL_DP = 8
+    companion object {
+        private const val PADDING_SMALL_HORIZONTAL_DP = 12
+        private const val PADDING_SMALL_VERTICAL_DP = 4
+        private const val PADDING_BIG_HORIZONTAL_DP = 20
+        private const val PADDING_BIG_VERTICAL_DP = 8
 
-        const val STYLE_PRIMARY_VIOLET = 1
-        const val STYLE_PRIMARY_GRAY = 2
-        const val STYLE_SECONDARY_GREEN = 3
-        const val STYLE_SECONDARY_GRAY = 4
-        const val STYLE_ONBOARDING_YELLOW = 5
-        const val STYLE_ONBOARDING_VIOLET = 6
+        private const val STYLE_PRIMARY_VIOLET = 1
+        private const val STYLE_PRIMARY_GRAY = 2
+        private const val STYLE_SECONDARY_GREEN = 3
+        private const val STYLE_SECONDARY_GRAY = 4
+        private const val STYLE_ONBOARDING_YELLOW = 5
+        private const val STYLE_ONBOARDING_VIOLET = 6
+
+        enum class Style {
+            PRIMARY_VIOLET,
+            PRIMARY_GRAY,
+            SECONDARY_GREEN,
+            SECONDARY_GRAY,
+            ONBOARDING_YELLOW,
+            ONBOARDING_VIOLET
+        }
     }
 }

--- a/uikit/src/main/res/drawable/tag_onboadring_yellow_background.xml
+++ b/uikit/src/main/res/drawable/tag_onboadring_yellow_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/attention" />
+    <corners android:radius="@dimen/card_radius_16" />
+</shape>

--- a/uikit/src/main/res/drawable/tag_onboarding_violet_background.xml
+++ b/uikit/src/main/res/drawable/tag_onboarding_violet_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/primary_base" />
+    <corners android:radius="@dimen/card_radius_16" />
+</shape>

--- a/uikit/src/main/res/drawable/tag_primary_gray_background.xml
+++ b/uikit/src/main/res/drawable/tag_primary_gray_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/icon_light" />
+    <corners android:radius="@dimen/card_radius_12" />
+</shape>

--- a/uikit/src/main/res/drawable/tag_primary_violet_background.xml
+++ b/uikit/src/main/res/drawable/tag_primary_violet_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/primary_base" />
+    <corners android:radius="@dimen/card_radius_12" />
+</shape>

--- a/uikit/src/main/res/drawable/tag_secodary_green_background.xml
+++ b/uikit/src/main/res/drawable/tag_secodary_green_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/secondary_base" />
+    <corners android:radius="@dimen/card_radius_18" />
+</shape>

--- a/uikit/src/main/res/drawable/tag_secondary_gray_background.xml
+++ b/uikit/src/main/res/drawable/tag_secondary_gray_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/icon_light" />
+    <corners android:radius="@dimen/card_radius_18" />
+</shape>

--- a/uikit/src/main/res/layout/tag_view.xml
+++ b/uikit/src/main/res/layout/tag_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
+    <TextView
+        android:id="@+id/tv_tag_view"
+        style="Text.Base.Medium.Regular"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        tools:text="Дима (вы)" />
+</FrameLayout>

--- a/uikit/src/main/res/values/custom_attrs.xml
+++ b/uikit/src/main/res/values/custom_attrs.xml
@@ -44,4 +44,14 @@
         <attr name="end_icon_is_visible" format="boolean" />
         <attr name="start_icon" format="reference" />
     </declare-styleable>
+
+    <declare-styleable name="TagView">
+        <attr name="tag_text" format="string" />
+        <attr name="tag_type" format="enum">
+            <enum name="primary_violet" value="1" />
+            <enum name="primary_gray" value="2" />
+            <enum name="secondary_green" value="3" />
+            <enum name="secondary_gray" value="4" />
+        </attr>
+    </declare-styleable>
 </resources>

--- a/uikit/src/main/res/values/custom_attrs.xml
+++ b/uikit/src/main/res/values/custom_attrs.xml
@@ -52,6 +52,8 @@
             <enum name="primary_gray" value="2" />
             <enum name="secondary_green" value="3" />
             <enum name="secondary_gray" value="4" />
+            <enum name="onboarding_yellow" value="5" />
+            <enum name="onboarding_violet" value="6" />
         </attr>
     </declare-styleable>
 </resources>

--- a/uikit/src/main/res/values/styles.xml
+++ b/uikit/src/main/res/values/styles.xml
@@ -64,4 +64,8 @@
         <item name="cornerFamily">rounded</item>
         <item name="cornerSize">@dimen/card_radius_16</item>
     </style>
+
+    <style name="Text.Base.SplashItem">
+        <item name="android:textSize">20sp</item>
+    </style>
 </resources>

--- a/uikit_sample/src/main/AndroidManifest.xml
+++ b/uikit_sample/src/main/AndroidManifest.xml
@@ -30,6 +30,8 @@
         <activity
             android:name=".MovieEvaluationExample"
             android:exported="false" />
+        <activity android:name=".TagViewExample"
+            android:exported="false" />
         <activity
             android:name=".MainActivity"
             android:exported="true">

--- a/uikit_sample/src/main/java/com/davai/uikit_sample/MainActivity.kt
+++ b/uikit_sample/src/main/java/com/davai/uikit_sample/MainActivity.kt
@@ -24,7 +24,8 @@ class MainActivity : AppCompatActivity() {
             btnToDvFilm,
             btnToDvSession,
             btnToDvMovieSelection,
-            btnToDvToolbar
+            btnToDvToolbar,
+            btnToDvTags
         ).forEach {
             it.setOnClickListener(onClickListener())
         }
@@ -70,6 +71,12 @@ class MainActivity : AppCompatActivity() {
                         this@MainActivity,
                         MovieSelectionExampleActivity::class.java
                     )
+                )
+
+                btnToDvTags -> startActivity(
+                    Intent(
+                        this@MainActivity,
+                        TagViewExample::class.java)
                 )
             }
         }

--- a/uikit_sample/src/main/java/com/davai/uikit_sample/MainActivity.kt
+++ b/uikit_sample/src/main/java/com/davai/uikit_sample/MainActivity.kt
@@ -76,7 +76,8 @@ class MainActivity : AppCompatActivity() {
                 btnToDvTags -> startActivity(
                     Intent(
                         this@MainActivity,
-                        TagViewExample::class.java)
+                        TagViewExample::class.java
+                    )
                 )
             }
         }

--- a/uikit_sample/src/main/java/com/davai/uikit_sample/TagViewExample.kt
+++ b/uikit_sample/src/main/java/com/davai/uikit_sample/TagViewExample.kt
@@ -1,0 +1,25 @@
+package com.davai.uikit_sample
+
+import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
+import com.davai.uikit.TagView
+
+class TagViewExample : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContentView(R.layout.activity_tag_view_example)
+
+        val thirdButton = findViewById<TagView>(R.id.tag_view3)
+        val fourthButton = findViewById<TagView>(R.id.tag_view4)
+
+        thirdButton.setOnClickListener {
+            thirdButton.setDisabled()
+        }
+
+        fourthButton.setOnClickListener {
+            fourthButton.setChosen()
+        }
+    }
+}

--- a/uikit_sample/src/main/java/com/davai/uikit_sample/TagViewExample.kt
+++ b/uikit_sample/src/main/java/com/davai/uikit_sample/TagViewExample.kt
@@ -15,11 +15,11 @@ class TagViewExample : AppCompatActivity() {
         val fourthButton = findViewById<TagView>(R.id.tag_view4)
 
         thirdButton.setOnClickListener {
-            thirdButton.setDisabled()
+            thirdButton.changeStyle(TagView.Companion.Style.SECONDARY_GRAY)
         }
 
         fourthButton.setOnClickListener {
-            fourthButton.setChosen()
+            fourthButton.changeStyle(TagView.Companion.Style.SECONDARY_GREEN)
         }
     }
 }

--- a/uikit_sample/src/main/res/layout/activity_main.xml
+++ b/uikit_sample/src/main/res/layout/activity_main.xml
@@ -84,4 +84,15 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/btn_to_dv_tags"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:backgroundTint="@color/done"
+        android:text="To DV Tags"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 </LinearLayout>

--- a/uikit_sample/src/main/res/layout/activity_tag_view_example.xml
+++ b/uikit_sample/src/main/res/layout/activity_tag_view_example.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".BannerViewExample"
+    tools:ignore="MissingDefaultResource">
+
+    <com.davai.uikit.TagView
+        android:id="@+id/tag_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:layout_marginHorizontal="@dimen/margin_16"
+        app:tag_text="Фильм"
+        app:tag_type="primary_violet"
+        />
+
+    <com.davai.uikit.TagView
+        android:id="@+id/tag_view2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_24"
+        android:layout_marginHorizontal="@dimen/margin_16"
+        app:tag_text="Фильм"
+        app:tag_type="primary_gray"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tag_view" />
+
+    <com.davai.uikit.TagView
+        android:id="@+id/tag_view3"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_24"
+        android:layout_marginHorizontal="@dimen/margin_16"
+        app:tag_text="Фильм"
+        app:tag_type="secondary_green"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tag_view2" />
+
+    <com.davai.uikit.TagView
+        android:id="@+id/tag_view4"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_24"
+        android:layout_marginHorizontal="@dimen/margin_16"
+        app:tag_text="Фильм"
+        app:tag_type="secondary_gray"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tag_view3" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/uikit_sample/src/main/res/layout/activity_tag_view_example.xml
+++ b/uikit_sample/src/main/res/layout/activity_tag_view_example.xml
@@ -57,4 +57,28 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/tag_view3" />
 
+    <com.davai.uikit.TagView
+        android:id="@+id/tag_view5"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_24"
+        android:layout_marginHorizontal="@dimen/margin_16"
+        app:tag_text="Фильм"
+        app:tag_type="onboarding_yellow"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tag_view4" />
+
+    <com.davai.uikit.TagView
+        android:id="@+id/tag_view6"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_24"
+        android:layout_marginHorizontal="@dimen/margin_16"
+        app:tag_text="Фильм"
+        app:tag_type="onboarding_violet"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tag_view5" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
#55 - кастомные тэги

В атрибут _tag_type_ можно передать 4 типа стиля: 

1.  **primary_violet** и **primary_gray** для отображения в карточке фильма, например: [Movie Selection](https://www.figma.com/design/18yNJmNYwWsexJku2SpWWE/%D0%94%D0%B0%D0%B2%D0%B0%D0%B9-%D0%BF%D0%BE%D1%81%D0%BC%D0%BE%D1%82%D1%80%D0%B8%D0%BC?node-id=4603-3472&t=LTbDIbHIzY54yJbN-0) (они меньше по размеру и цвета фиолетовый/серый)
2. **secondary_green** и **secondary_gray** для всех остальных экранов (больше по размеру, цвета зеленый/серый)

Публичные методы для установки текста и смены состояния выбранный/невыбранный (для экрана [создания сессии](https://www.figma.com/design/18yNJmNYwWsexJku2SpWWE/%D0%94%D0%B0%D0%B2%D0%B0%D0%B9-%D0%BF%D0%BE%D1%81%D0%BC%D0%BE%D1%82%D1%80%D0%B8%D0%BC?node-id=472-6800&t=LTbDIbHIzY54yJbN-0))